### PR TITLE
Fix skips

### DIFF
--- a/src/Utils/parseData.js
+++ b/src/Utils/parseData.js
@@ -143,18 +143,24 @@ export function parseDiskIO (sarFileData) {
     const uniqDev = [];
 
 
-    const prasedData = sarFileData;
 
-    const rowIncludesIOIndex = sarFileData.map((row, index) => row.includes('DEV') ? index : null ).filter(index => typeof index === 'number'); // Verify if row includes DEV and returns index of matching pattern. Returns the index of the ocurrences of 'DEV'.
+    const prasedData = sarFileData.filter(row => {
+        if(row.length === 10 && isNaN(row[1]) && !row.includes('pgpgin/s')) {
+            return true;
+        }
+    });
 
-    const firstIndex = rowIncludesIOIndex[0] + 1; // first index not including the first instance which is the header
-    const averageIndex = sarFileData.map((row, index) => row.includes('Average:') ? index : null ).filter(index => typeof index === 'number'); // Obtains an array with the occurences of the Average: 
-    const lastIndexAvg = averageIndex.filter(element => element > rowIncludesIOIndex[0]); //Looks for values greater than the first index of DEV and returns the array with the data between DEV and Average
-    const lastIndex = lastIndexAvg[0]; //Grabs the first element of the array which is the last index
+    // const rowIncludesIOIndex = sarFileData.map((row, index) => row.includes('DEV') ? index : null ).filter(index => typeof index === 'number'); // Verify if row includes DEV and returns index of matching pattern. Returns the index of the ocurrences of 'DEV'.
 
-    const ioData = returnDataPortion(firstIndex, lastIndex, prasedData); // returns the portion of the data from firstIndex to lastIndex
+    // const firstIndex = rowIncludesIOIndex[0] + 1; // first index not including the first instance which is the header
+    // const averageIndex = sarFileData.map((row, index) => row.includes('Average:') ? index : null ).filter(index => typeof index === 'number'); // Obtains an array with the occurences of the Average: 
+    // const lastIndexAvg = averageIndex.filter(element => element > rowIncludesIOIndex[0]); //Looks for values greater than the first index of DEV and returns the array with the data between DEV and Average
+    // const lastIndex = lastIndexAvg[0]; //Grabs the first element of the array which is the last index
 
-    const filteredArray = ioData.filter(row => !row.includes('DEV')) // return everything that does not include the word "%usr" which indicates a header
+    // const ioData = returnDataPortion(firstIndex, lastIndex, prasedData); // returns the portion of the data from firstIndex to lastIndex
+
+    const filteredArray = prasedData.filter(row => !row.includes('DEV') && !row.includes('Average:')) // return everything that does not include the word "%usr" which indicates a header
+
     filteredArray.forEach(row =>{ //pushes values to the array
         const blockDev = row[1];
         xlables.push(row[0]);


### PR DESCRIPTION
Linux restarts would cause data to skip in the sar file, basically break consecutive sections. This PR fixes that by parsing the data differently